### PR TITLE
[squid:S2786] Nested "enum"s should not be declared static

### DIFF
--- a/src/main/java/setvis/bubbleset/Intersection.java
+++ b/src/main/java/setvis/bubbleset/Intersection.java
@@ -20,7 +20,7 @@ public final class Intersection extends Point2D.Double {
    * 
    * @author Christopher Collins
    */
-  public static enum State {
+  public enum State {
     /** a point intersection */
     Point,
     /** parrallel */

--- a/src/main/java/setvis/bubbleset/MarchingSquares.java
+++ b/src/main/java/setvis/bubbleset/MarchingSquares.java
@@ -14,7 +14,7 @@ public final class MarchingSquares {
     // no constructor
   }
 
-  private static enum Direction {
+  private enum Direction {
     N, S, E, W
   }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2786 - “Nested "enum"s should not be declared static”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2786

Please let me know if you have any questions.
Ayman Abdelghany.